### PR TITLE
Rewrite generator with React

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
 # reddit-snoo-generator
-Snoo (The Reddit alien) Generator using HTML5, Vanilla CSS, Vanilla JS, JQuery
 
-[Snoo (The Reddit alien) Generator](http://hoodoo.me/reddit-snoo-generator)
+A small Reddit Snoo generator built with React, TypeScript and Material UI.
+
+## Development
+
+This project uses [Vite](https://vitejs.dev/) for the dev server and build step.
+
+```bash
+npm install
+npm run dev
+```
+
+When the dev server starts it prints a local address (usually `http://localhost:5173`).
+Open that URL in your browser to see the generator UI.

--- a/index.html
+++ b/index.html
@@ -1,114 +1,12 @@
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <script>
-      function generate() {
-        let x = Math.floor(Math.random() * 20 + 1).toString();
-        if (x.length == 1) {
-          x = "0" + x;
-        }
-        let redditAvatar = [
-          "A5A4A4",
-          "545452",
-          "A06A42",
-          "C18D42",
-          "FF4500",
-          "FF8717",
-          "FFB000",
-          "FFD635",
-          "DDBD37",
-          "D4E815",
-          "94E044",
-          "46A508",
-          "46D160",
-          "0DD3BB",
-          "25B79F",
-          "008985",
-          "24A0ED",
-          "0079D3",
-          "7193FF",
-          "4856A3",
-          "7E53C1",
-          "FF66AC",
-          "DB0064",
-          "EA0027",
-          "FF585B",
-        ];
-        const snoo =
-          redditAvatar[Math.floor(Math.random() * redditAvatar.length)];
-        let img =
-          "<img src='https://www.redditstatic.com/avatars/avatar_default_" +
-          x +
-          "_" +
-          snoo +
-          ".png'>";
-        document.querySelector("#view").innerHTML = img;
-        document.querySelector("#snoo").innerHTML = "Snoo style : " + x;
-        document.querySelector("#hexcode").innerHTML = "Hexcode : #" + snoo;
-        document.querySelector("#hexcode").style.color = "#" + snoo;
-        document.querySelector("#generate").style.backgroundColor = "#" + snoo;
-      }
-    </script>
-    <style>
-      body {
-        background-color: rgb(248, 245, 245);
-        margin: 0;
-      }
-      #text {
-        margin-bottom: 3%;
-        margin-top: 5%;
-      }
-      .container {
-        text-align: center;
-        padding: 20px 15px;
-        box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
-        width: 300px;
-        margin: auto;
-        background-color: white;
-        height: 380px;
-      }
-      .container button {
-        margin-top: 15px;
-        outline: none;
-        border-radius: 5px;
-        cursor: pointer;
-        padding: 10px 15px;
-        font-size: 20px;
-        background-color: yellowgreen;
-        border: none;
-        color: white;
-      }
-      #view {
-        height: 256px;
-      }
-    </style>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Snoo (The Reddit alien) Generator</title>
   </head>
-  <body onload="generate()">
-    <div id="text" style="text-align: center;">
-      <h2>Snoo (The Reddit alien) Generator</h2>
-    </div>
-    <div class="container">
-      <div id="view"></div>
-      <br />
-      <div id="snoo"></div>
-      <div id="hexcode"></div>
-      <div id="load">Loading...</div>
-      <button id="generate" onclick="generate()">
-        Generate
-      </button>
-    </div>
-
-    <script>
-      $(document).ready(function () {
-        $("#view").ready(function () {
-          $("#load").hide();
-        });
-      });
-    </script>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>
-

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "reddit-snoo-generator",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@mui/material": "^5.15.11",
+    "@emotion/react": "^11.10.6",
+    "@emotion/styled": "^11.10.6"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.20",
+    "@types/react-dom": "^18.2.7",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.2.1"
+  }
+}

--- a/src/SnooGenerator.tsx
+++ b/src/SnooGenerator.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+import { Container, Button, Typography, Box } from '@mui/material';
+
+interface Snoo {
+  style: string;
+  color: string;
+  url: string;
+}
+
+function getRandomSnoo(): Snoo {
+  const avatars = [
+    'A5A4A4',
+    '545452',
+    'A06A42',
+    'C18D42',
+    'FF4500',
+    'FF8717',
+    'FFB000',
+    'FFD635',
+    'DDBD37',
+    'D4E815',
+    '94E044',
+    '46A508',
+    '46D160',
+    '0DD3BB',
+    '25B79F',
+    '008985',
+    '24A0ED',
+    '0079D3',
+    '7193FF',
+    '4856A3',
+    '7E53C1',
+    'FF66AC',
+    'DB0064',
+    'EA0027',
+    'FF585B',
+  ];
+  const style = String(Math.floor(Math.random() * 20 + 1)).padStart(2, '0');
+  const color = avatars[Math.floor(Math.random() * avatars.length)];
+  return {
+    style,
+    color,
+    url: `https://www.redditstatic.com/avatars/avatar_default_${style}_${color}.png`,
+  };
+}
+
+export default function SnooGenerator() {
+  const [snoo, setSnoo] = useState<Snoo | null>(null);
+
+  useEffect(() => {
+    handleGenerate();
+  }, []);
+
+  const handleGenerate = () => {
+    setSnoo(getRandomSnoo());
+  };
+
+  if (!snoo) return null;
+
+  return (
+    <Container sx={{ textAlign: 'center', mt: 4, p: 2, boxShadow: 2, width: 300, bgcolor: 'background.paper', height: 380 }}>
+      <Box sx={{ height: 256 }}>
+        <img src={snoo.url} alt="snoo" />
+      </Box>
+      <Typography variant="body1" sx={{ mt: 1 }}>
+        Snoo style: {snoo.style}
+      </Typography>
+      <Typography variant="body1" sx={{ color: `#${snoo.color}` }}>
+        Hexcode: #{snoo.color}
+      </Typography>
+      <Button variant="contained" onClick={handleGenerate} sx={{ mt: 2, bgcolor: `#${snoo.color}` }}>
+        Generate
+      </Button>
+    </Container>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { CssBaseline } from '@mui/material';
+import SnooGenerator from './SnooGenerator';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <CssBaseline />
+    <SnooGenerator />
+  </React.StrictMode>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- restructure project for React and TypeScript using Vite
- move generator logic to `SnooGenerator.tsx`
- update README with development instructions
- clarify README instructions for accessing the running UI

## Testing
- `node -e "const fs=require('fs');fs.readFile('src/SnooGenerator.tsx','utf8',(e,d)=>{if(e)throw e; console.log('length', d.length);});"`
- `npm run dev` *(captured output shows URL)*

------
https://chatgpt.com/codex/tasks/task_e_6843c51e34bc832bbda7dc15af7794bf