### PR TITLE
Fix GitHub build deploy instructions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -13,3 +13,23 @@ npm run dev
 
 When the dev server starts it prints a local address (usually `http://localhost:5173`).
 Open that URL in your browser to see the generator UI.
+
+## Deploying to GitHub Pages
+
+GitHub Pages serves static files only. The `index.html` in this repository
+expects Vite to compile `/src/main.tsx` at runtime, which does not happen when
+served from Pages. To deploy the app you need to build the project first and
+upload the contents of the generated `dist` folder.
+
+```bash
+npm run build
+```
+
+After the build finishes, point GitHub Pages to the `dist/` directory (or push
+that directory to a separate branch such as `gh-pages`). The site will then load
+the compiled JavaScript instead of the raw TypeScript entry file.
+
+You can automate this step with GitHub Actions. The workflow in
+`.github/workflows/deploy.yml` installs dependencies, runs `npm run build` and
+publishes the generated `dist/` folder to GitHub Pages whenever changes are
+pushed to the `master` branch.


### PR DESCRIPTION
## Summary
- add `.gitignore` for build artifacts
- document automatic GitHub Pages deployment
- add `deploy.yml` GitHub Actions workflow

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843ccdb7074832b868517485b0309c8